### PR TITLE
fix RewardModel forward bug

### DIFF
--- a/training/models/reward_model.py
+++ b/training/models/reward_model.py
@@ -192,7 +192,7 @@ class RewardModel(transformers.PreTrainedModel):
             output_hidden_states=True,
             **kwargs,
         )
-        last_hidden_state = outputs.hidden_states[-1]
+        last_hidden_state = outputs.hidden_states[-1].permute(1, 0, 2)
         assert isinstance(last_hidden_state, torch.Tensor), f"{outputs}"
         # last_hidden_state = outputs.last_hidden_state
         # TODO(zhiqings): Hacking to make sure every parameter is used in the backward pass.


### PR DESCRIPTION
when call model(args)
before: return tensor.Size(seq_len)
now: return tensor.Size(bsz*num_candidates)
...